### PR TITLE
Fix pub and add ID filter

### DIFF
--- a/internal/integration/knot/entities/device.go
+++ b/internal/integration/knot/entities/device.go
@@ -2,15 +2,14 @@ package entities
 
 // States that represent the current status of the device on the Knot network
 const (
-	KnotNew           string = "new"
-	KnotRegisterReq          = "registerRequest"
-	KnotUnregisterReq        = "registerUnrequest"
-	KnotRegistered           = "registered"
-	KnotDelete               = "delete"
-	KnotForceDelete          = "forceDelete"
-	KnotOk                   = "readToSendData"
-	KnotAuth                 = "authenticated"
-	KnotError                = "error"
+	KnotNew         string = "new"
+	KnotRegistered         = "registered"
+	KnotDelete             = "delete"
+	KnotForceDelete        = "forceDelete"
+	KnotOk                 = "readToSendData"
+	KnotAuth               = "authenticated"
+	KnotError              = "error"
+	KnotWait               = "waitResponse"
 )
 
 // Device represents the device domain entity

--- a/internal/integration/knot/network/amqp.go
+++ b/internal/integration/knot/network/amqp.go
@@ -13,6 +13,7 @@ const (
 	exchangeTypeFanout = "fanout"
 
 	exchangeDevice      = "device"
+	exchangeSent        = "data.sent"
 	ReplyToAuthMessages = "chirpstack-auth-rpc"
 )
 

--- a/internal/integration/knot/network/publisher.go
+++ b/internal/integration/knot/network/publisher.go
@@ -122,7 +122,7 @@ func (mp *msgPublisher) PublishDeviceData(userToken string, device *entities.Dev
 		Data: data,
 	}
 
-	err := mp.amqp.PublishPersistentMessage(exchangeDevice, exchangeTypeFanout, routingKeyDataSent, message, &options)
+	err := mp.amqp.PublishPersistentMessage("data.published", exchangeTypeFanout, "", message, &options)
 	if err != nil {
 		return err
 	}

--- a/internal/integration/knot/network/publisher.go
+++ b/internal/integration/knot/network/publisher.go
@@ -9,7 +9,6 @@ const (
 	routingKeyUnregister   = "device.unregister"
 	routingKeyAuth         = "device.auth"
 	routingKeyUpdateConfig = "device.config.sent"
-	routingKeyDataSent     = "data.sent"
 
 	defaultCorrelationID = "default-corrId"
 
@@ -122,7 +121,7 @@ func (mp *msgPublisher) PublishDeviceData(userToken string, device *entities.Dev
 		Data: data,
 	}
 
-	err := mp.amqp.PublishPersistentMessage("data.published", exchangeTypeFanout, "", message, &options)
+	err := mp.amqp.PublishPersistentMessage(exchangeSent, exchangeTypeFanout, "", message, &options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Now the device checks the id of messages that arrive via AMQP, thus avoiding receiving devices from another service.

With this verification, it is now possible to use only one user token for more than one service.

Also done the correction of the Exchange AMQP of sending data, now the data goes through the Babeltower of the Knot. This was done in the last commit.